### PR TITLE
Fixes for instrumented Erigon build

### DIFF
--- a/ethereum-testnet-bootstrapper/execution-clients/erigon_devel-inst.Dockerfile
+++ b/ethereum-testnet-bootstrapper/execution-clients/erigon_devel-inst.Dockerfile
@@ -16,15 +16,27 @@ arg erigon_branch="devel"
 
 run mkdir -p /build
 
-run git clone --depth 1 https://github.com/ledgerwatch/erigon.git
-
-run cd erigon \
-    && git checkout ${erigon_branch} \
-    && git submodule update --init
+# TODO: Adding --depth 1 sometimes causes issues for some reason
+run git clone --recurse-submodules -j8 \
+	https://github.com/ledgerwatch/erigon.git -b ${erigon_branch}
 
 # add items to this exclusions list to exclude them from instrumentation
 RUN touch /opt/antithesis/go_instrumentation/exclusions.txt
-RUN echo "cmd/sentry/sentry/sentry_multi_client.go" >> /opt/antithesis/go_instrumentation/exclusions.txt
+# These exclusions are mostly due to this issue:
+# https://trello.com/c/Wmaxylu9/1271-go-instrumentor-strips-out-v117-conditional-compilation-comments-directives
+RUN echo "cmd/sentry/sentry/sentry_multi_client.go\n\
+interfaces.go\n\
+rules.go\n\
+tools.go\n\
+internal/debug/\n\
+tests/\n\
+core/block_proposer.go\n\
+core/mkalloc.go\n\
+core/types/receipt_codecgen_gen.go\n\
+crypto/\n\
+p2p/netutil/toobig_notwindows.go\n\
+p2p/netutil/toobig_windows.go\n\
+common/fdlimit/" >> /opt/antithesis/go_instrumentation/exclusions.txt
 
 # Antithesis -------------------------------------------------
 WORKDIR /git
@@ -32,14 +44,9 @@ RUN mkdir -p erigon_instrumented && LD_LIBRARY_PATH=/opt/antithesis/go_instrumen
 RUN cp -r erigon_instrumented/customer/* erigon/
 RUN cd erigon && go mod edit -require=antithesis.com/instrumentation/wrappers@v1.0.0 -replace antithesis.com/instrumentation/wrappers=/opt/antithesis/go_instrumentation/instrumentation/go/wrappers
 # Antithesis -------------------------------------------------
-# Get dependencies
-RUN cd /git/erigon/ && go get -t -d ./...
 
-# TODO revisit once non-instrumented version is working
-#  && CGO_CFLAGS="-I/opt/antithesis/go_instrumentation/include" CGO_LDFLAGS="-L/opt/antithesis/go_instrumentation/lib" make erigon
-#
-run cd erigon/ \
-    && CGO_CFLAGS="-I/opt/antithesis/go_instrumentation/include" make erigon
+RUN cd erigon/ \
+    && CGO_CFLAGS="-I/opt/antithesis/go_instrumentation/include" CGO_LDFLAGS="-L/opt/antithesis/go_instrumentation/lib" make erigon
 
 RUN cd erigon && git log -n 1 --format=format:"%H" > /erigon.version
 FROM etb-client-runner

--- a/ethereum-testnet-bootstrapper/execution-clients/erigon_devel-inst.Dockerfile
+++ b/ethereum-testnet-bootstrapper/execution-clients/erigon_devel-inst.Dockerfile
@@ -16,7 +16,7 @@ arg erigon_branch="devel"
 
 run mkdir -p /build
 
-run git clone https://github.com/ledgerwatch/erigon.git
+run git clone --depth 1 https://github.com/ledgerwatch/erigon.git
 
 run cd erigon \
     && git checkout ${erigon_branch} \
@@ -30,14 +30,14 @@ RUN echo "cmd/sentry/sentry/sentry_multi_client.go" >> /opt/antithesis/go_instru
 WORKDIR /git
 RUN mkdir -p erigon_instrumented && LD_LIBRARY_PATH=/opt/antithesis/go_instrumentation/lib /opt/antithesis/go_instrumentation/bin/goinstrumentor -antithesis=/opt/antithesis/go_instrumentation/instrumentation/go/wrappers/ -exclude=/opt/antithesis/go_instrumentation/exclusions.txt -stderrthreshold=INFO erigon erigon_instrumented
 RUN cp -r erigon_instrumented/customer/* erigon/
-RUN cd erigon && go mod edit -require=antithesis.com/instrumentation/wrappers@v1.0.0 -replace antithesis.com/instrumentation/wrappers=/opt/antithesis/go_instrumentation/instrumentation/go/wrappers 
+RUN cd erigon && go mod edit -require=antithesis.com/instrumentation/wrappers@v1.0.0 -replace antithesis.com/instrumentation/wrappers=/opt/antithesis/go_instrumentation/instrumentation/go/wrappers
 # Antithesis -------------------------------------------------
 # Get dependencies
 RUN cd /git/erigon/ && go get -t -d ./...
 
 # TODO revisit once non-instrumented version is working
 #  && CGO_CFLAGS="-I/opt/antithesis/go_instrumentation/include" CGO_LDFLAGS="-L/opt/antithesis/go_instrumentation/lib" make erigon
-# 
+#
 run cd erigon/ \
     && CGO_CFLAGS="-I/opt/antithesis/go_instrumentation/include" make erigon
 

--- a/ethereum-testnet-bootstrapper/execution-clients/erigon_devel.Dockerfile
+++ b/ethereum-testnet-bootstrapper/execution-clients/erigon_devel.Dockerfile
@@ -16,11 +16,8 @@ arg erigon_branch="devel"
 
 run mkdir -p /build
 
-run git clone --depth 1 https://github.com/ledgerwatch/erigon.git
-
-run cd erigon \
-    && git checkout ${erigon_branch} \
-    && git submodule update --init
+run git clone --depth 1 --recurse-submodules -j8 \
+	https://github.com/ledgerwatch/erigon.git -b ${erigon_branch}
 
 run cd erigon/ \
     && make erigon

--- a/ethereum-testnet-bootstrapper/execution-clients/erigon_devel.Dockerfile
+++ b/ethereum-testnet-bootstrapper/execution-clients/erigon_devel.Dockerfile
@@ -16,7 +16,7 @@ arg erigon_branch="devel"
 
 run mkdir -p /build
 
-run git clone https://github.com/ledgerwatch/erigon.git
+run git clone --depth 1 https://github.com/ledgerwatch/erigon.git
 
 run cd erigon \
     && git checkout ${erigon_branch} \


### PR DESCRIPTION
The instrumented Erigon build was not working due to the Go instrumentor not handling conditional compilation directive comments correctly.